### PR TITLE
Add initial tests for utilities and schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "format": "npx prettier . --write",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "rm -rf storybook-static && storybook build"
+    "build-storybook": "rm -rf storybook-static && storybook build",
+    "test": "vitest run"
   },
   "dependencies": {
     "@apollo/client": "^3.8.8",

--- a/src/features/articles/validations/__tests__/schema.test.ts
+++ b/src/features/articles/validations/__tests__/schema.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import schema from '../schema'
+
+describe('記事スキーマ', () => {
+  it('正しいデータを検証できる', () => {
+    const data = {
+      entryId: '1',
+      id: '1',
+      title: 'title',
+      body: 'body',
+      publicAt: new Date('2024-01-01'),
+      views: '10',
+    }
+    const result = schema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+
+  it('idが範囲外の場合は失敗する', () => {
+    const data = {
+      id: '0',
+      title: 't',
+      body: 'b',
+      publicAt: new Date('2024-01-01'),
+      views: '1',
+    }
+    const result = schema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { isValidDate, convertToIsoUtc } from '../date'
+
+describe('isValidDate関数', () => {
+  it('有効な日付文字列なら true を返す', () => {
+    expect(isValidDate('2024-01-01')).toBe(true)
+  })
+
+  it('無効な日付文字列なら false を返す', () => {
+    expect(isValidDate('invalid-date')).toBe(false)
+  })
+})
+
+describe('convertToIsoUtc関数', () => {
+  it('yyyymmdd 文字列を ISO UTC に変換する', () => {
+    const iso = convertToIsoUtc('20240101')
+    expect(iso.startsWith('2024-01-01T00:00:00')).toBe(true)
+  })
+})

--- a/src/utils/__tests__/schemaHelpers.test.ts
+++ b/src/utils/__tests__/schemaHelpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { zIntInRange, zLimitedText } from '../schemaHelpers'
+
+describe('zIntInRange関数', () => {
+  const schema = zIntInRange('テスト', 1, 10)
+
+  it('範囲内の数値を解析できる', () => {
+    expect(schema.parse('5')).toBe(5)
+  })
+
+  it('範囲外の数値は失敗する', () => {
+    const result = schema.safeParse('0')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors['']).toBeUndefined()
+    }
+  })
+})
+
+describe('zLimitedText関数', () => {
+  const schema = zLimitedText('名前', 5)
+
+  it('空でない文字列を解析できる', () => {
+    expect(schema.parse('abc')).toBe('abc')
+  })
+
+  it('空文字列は失敗する', () => {
+    const result = schema.safeParse('')
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for date and schema helpers
- add validation schema test
- provide npm test script
- test names in Japanese

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684516b8b7f883228217cb8908bc821f